### PR TITLE
Make tests pass against MS SQL

### DIFF
--- a/t/main.t
+++ b/t/main.t
@@ -114,7 +114,7 @@ $dbh->{syb_quoted_identifier} = 0;
 # Test multiple result sets, varying column names
 $sth = $dbh->prepare("
 select uid, name from sysusers where uid = -2
-select spid, kpid, suid from master..sysprocesses where spid = \@\@spid
+select spid, kpid, uid from master..sysprocesses where spid = \@\@spid
 ");
 ok($sth, 'prepare multiple');
 $rc = $sth->execute;
@@ -159,10 +159,10 @@ SKIP: {
     ok($desc[0]->{TYPE} == 8, 'describe TYPE');
 }
 
-$sth = $dbh->prepare(q|select suid, suser_name(suid), cpu, physical_io
+$sth = $dbh->prepare(q|select uid, suser_name(uid), cpu, physical_io
 from master..sysprocesses
-order by suid
-compute sum(cpu), sum(physical_io) by suid
+order by uid
+compute sum(cpu), sum(physical_io) by uid
 		       |
 );
 

--- a/t/multi_sth.t
+++ b/t/multi_sth.t
@@ -88,7 +88,7 @@ sub test2 {
 
 	my $sth1 = $dbh->prepare("select * from master..sysprocesses where spid = ?");
 	ok(defined($sth1), 'test2 prepare1');
-	my $sth2 = $dbh->prepare("select * from sysusers where suid = ?");
+	my $sth2 = $dbh->prepare("select * from sysusers where uid = ?");
 	ok(defined($sth2), 'test2 prepare2');
 	
 	$rc = $sth1->execute(1);
@@ -128,7 +128,7 @@ sub test3 {
 
 	my $sth1 = $dbh->prepare("select * from master..sysprocesses where spid = ?");
 	ok(defined($sth1), 'test3 prepare1');
-	my $sth2 = $dbh->prepare("select * from sysusers where suid = ?");
+	my $sth2 = $dbh->prepare("select * from sysusers where uid = ?");
 	ok(defined($sth2), 'test3 prepare2');
 
 	$rc = $sth1->execute(1);

--- a/t/place.t
+++ b/t/place.t
@@ -27,17 +27,20 @@ SKIP: {
 
     my $rc;
 
+    my $jan03 = 'Jan 3 1998';
+    my $jan25 = 'Jan 25 1998';
+
     $rc = $dbh->do("create table #t(string varchar(20), date datetime, val float, other_val numeric(9,3))");
     ok($rc, 'Create table');
 
     my $sth = $dbh->prepare("insert #t values(?, ?, ?, ?)");
     ok($sth, 'prepare');
     
-    $rc = $sth->execute("test", "Jan 3 1998", 123.4, 222.3334);
+    $rc = $sth->execute("test", $jan03, 123.4, 222.3334);
     ok($rc, 'insert 1');
 
     ok $sth->bind_param(1, "other test");
-    ok $sth->bind_param(2, "Jan 25 1998");
+    ok $sth->bind_param(2, $jan25);
     # the order of these two bind_param's is swapped on purpose
     ok $sth->bind_param(4, 2);
     ok $sth->bind_param(3, 4445123.4);
@@ -56,21 +59,25 @@ SKIP: {
     $rc = $sth->execute('Jan 1 1998', 120);
     ok($rc, 'select');
 
+    # get the dates in the expected locale format
+    my $sthDates = $dbh->prepare(
+        "select convert(datetime, '$jan03'), convert(datetime, '$jan25')");
+    $sthDates->execute;
+    my ($jan03formatted, $jan25formatted) = @{$sthDates->fetchall_arrayref->[0]};
+
     my $rows = $sth->fetchall_arrayref;
     is(@$rows, 2, 'fetch count');
-    is_deeply [
-        [ 'test', 'Jan  3 1998 12:00AM', '123.4', '222.333' ],
-        [ 'other test', 'Jan 25 1998 12:00AM', '4445123.4', '2.000' ]
-    ], $rows;
-
+    is_deeply $rows, [
+        [ 'test', $jan03formatted, '123.4', '222.333' ],
+        [ 'other test', $jan25formatted, '4445123.4', '2.000' ]
+    ];
 
     ok $sth->execute('Jan 1 1998', 140);
     $rows = $sth->fetchall_arrayref;
     is(@$rows, 1, 'fetch 2');
-    is_deeply [
-        [ 'other test', 'Jan 25 1998 12:00AM', '4445123.4', '2.000' ]
-    ], $rows;
-
+    is_deeply $rows, [
+        [ 'other test', $jan25formatted, '4445123.4', '2.000' ]
+    ];
 }
 $dbh->disconnect;
 


### PR DESCRIPTION
The sysusers.suid field is not available on MS SQL, and sysusers.uid should work just
as fine. Fixes #65.

The datetime formats are different in MS SQL and/or FreeTDS. Fixes #66.