### PR TITLE
bugfix for undefined CS_BIGTIME_TYPE

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5391,7 +5391,7 @@ static int time2str(ColData *colData, CS_DATAFMT *srcfmt, char *buff, CS_INT len
 #endif
     {
       datatype = CS_TIME_TYPE;
-      value = &colData->value.bt;
+      value = &colData->value.t;
     }
 
     cs_dt_crack(context, datatype, value, &rec);


### PR DESCRIPTION
compilation error fixed, when CS_BIGTIME_TYPE is not defined

dbdimp.c: In function ‘time2str’:
dbdimp.c:5394:31: error: ‘union <anonymous>’ has no member named ‘bt’; did you mean ‘bi’?
 5394 |       value = &colData->value.bt;
      |                               ^~
      |                               bi