### PR TITLE
Allow user IDs and passwords greater than 31 bytes.

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1188,10 +1188,10 @@ int syb_db_login(SV *dbh, imp_dbh_t *imp_dbh, char *dsn, char *uid, char *pwd, S
     imp_dbh->server[63] = 0;
   }
 
-  strncpy(imp_dbh->uid, uid, 32);
-  imp_dbh->uid[31] = 0;
-  strncpy(imp_dbh->pwd, pwd, 32);
-  imp_dbh->pwd[31] = 0;
+  strncpy(imp_dbh->uid, uid, UID_PWD_SIZE);
+  imp_dbh->uid[UID_PWD_SIZE - 1] = 0;
+  strncpy(imp_dbh->pwd, pwd, UID_PWD_SIZE);
+  imp_dbh->pwd[UID_PWD_SIZE - 1] = 0;
 
   sv_setpv(DBIc_ERRSTR(imp_dbh), "");
 

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -56,6 +56,8 @@ struct imp_drh_st {
 #define MAX_SQL_SIZE 255
 #define VERSION_SIZE 20
 
+#define UID_PWD_SIZE 256
+
 /* Define dbh implementor data structure */
 struct imp_dbh_st {
 	dbih_dbc_t com; /* MUST be first element in structure	*/
@@ -76,8 +78,8 @@ struct imp_dbh_st {
 	int lasterr;
 	int lastsev;
 
-	char uid[32];
-	char pwd[32];
+	char uid[UID_PWD_SIZE];
+	char pwd[UID_PWD_SIZE];
 
 	char server[64];
 	char charset[64];


### PR DESCRIPTION
Increase size of uid and pwd fields to 255.