### PR TITLE
Avoid assigning uninitialized local variable to itself

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5422,7 +5422,6 @@ static int to_numeric(char *str, SV *sth, imp_sth_t *imp_sth, CS_DATAFMT *datafm
   CS_DATAFMT srcfmt;
   CS_INT reslen;
   char *p;
-  CS_LOCALE *locale = LOCALE(imp_dbh);
 
   memset(mn, 0, sizeof(*mn));
 
@@ -5433,7 +5432,7 @@ static int to_numeric(char *str, SV *sth, imp_sth_t *imp_sth, CS_DATAFMT *datafm
   memset(&srcfmt, 0, sizeof(srcfmt));
   srcfmt.datatype = CS_CHAR_TYPE;
   srcfmt.format = CS_FMT_NULLTERM;
-  srcfmt.locale = locale;
+  srcfmt.locale = LOCALE(imp_dbh);
 
   /* According to  https://github.com/mpeppler/DBD-Sybase/issues/31 we need to set the 
      datafmt.maxlength value to 35. This is not needed with Sybase client libs, but 


### PR DESCRIPTION
After expanding the ```LOCALE``` macro, the code expands to ```CS_LOCALE *locale = ((imp_dbh)->locale ? (imp_dbh)->locale : locale);```

When ```imp_dbh->locale``` is ```NULL```, this gives undefined behavior. On AIX, it is interpreted as assigning the local variable to itself (i.e. leaving it uninitialized).  It seems some compilers must be smart enough to realize the real intent, and accordingly copy the value of the global variable, which would explain why more people aren't experiencing the same issue.

Fixes #114.