### PR TITLE
Fixed double free on 2nd failed connect attempt

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1567,7 +1567,9 @@ non-encrypted retries */
       // Try to connect - if this fails we do some cleanup...
       if ((retcode = ct_connect(connection, imp_dbh->server, len)) != CS_SUCCEED) {
         if (glocale != NULL) {
-          cs_loc_drop(context, glocale);
+          if (cs_loc_drop(context, glocale) == CS_SUCCEED) {
+            glocale = NULL;
+          }
         }
         ct_con_drop(connection);
         return 0;
@@ -1586,7 +1588,9 @@ non-encrypted retries */
         /* cleanup, and return NULL */
         ct_close(connection, CS_FORCE_CLOSE);
         if (glocale != NULL) {
-          cs_loc_drop(context, glocale);
+          if (cs_loc_drop(context, glocale) == CS_SUCCEED) {
+            glocale = NULL;
+          }
         }
         ct_con_drop(connection);
 

--- a/t/connect_fail.t
+++ b/t/connect_fail.t
@@ -1,0 +1,32 @@
+#!perl
+
+use lib 'blib/lib';
+use lib 'blib/arch';
+
+use lib 't';
+use _test;
+
+use strict;
+
+use Test::More tests => 4;
+
+use vars qw($Pwd $Uid $Srv $Db);
+
+BEGIN { use_ok('DBI');
+        use_ok('DBD::Sybase');}
+
+($Uid, $Pwd, $Srv, $Db) = _test::get_info();
+
+$Srv = "invalid_srv";
+
+#DBI->trace(3);
+my $dbh = DBI->connect("dbi:Sybase:$Srv;database=$Db", $Uid, $Pwd, {PrintError => 0, RaiseError => 0});
+#DBI->trace(0);
+
+ok(!defined($dbh), "$Srv is not available");
+
+$dbh = DBI->connect("dbi:Sybase:$Srv;database=$Db", $Uid, $Pwd, {PrintError => 0, RaiseError => 0});
+
+ok(!defined($dbh), "$Srv is not available after retry");
+
+exit(0);


### PR DESCRIPTION
Hello,

2nd attempt to connect to non-existent (or not started yet) server causes segmentation fault.
cs_loc_drop(context, glocale) called with the same address for 1st and 2nd attempts both.

Added a fix and a new test. Could you please review?
